### PR TITLE
cron job 0 8 16 hours

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,7 +3,7 @@ name: Scrape Oakland calls for service
 
 on:
   schedule:
-  - cron: "0 19 * * *"
+  - cron: "0 */8 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This is supposed to be insurance against periodic failures.

Do we need to change anything else to make the action not break? I didn't consider the process by which new files are saved.

We probably don't need to do this if we add retries: #1